### PR TITLE
Add graphify knowledge-graph integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ htmlcov/
 # IDE
 .vscode/
 .idea/
+
+# Graphify knowledge graph (regenerable; per-developer)
+graphify-out/
+.graphifyignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Python
 __pycache__/
 *.pyc
 *.pyo
@@ -31,6 +32,10 @@ htmlcov/
 .vscode/
 .idea/
 
+# Claude Code local state — share settings.json (team config), keep everything else local
+.claude/*
+!.claude/settings.json
+
 # Graphify knowledge graph (regenerable; per-developer)
 graphify-out/
-.graphifyignore
+graphify-out-*/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,23 @@
+# Test files — test relationships aren't the domain model
+tests/
+
+# Deployment config — no code relationships
+render.yaml
+
+# Dependency manifests — no graph signal
+requirements.txt
+pyproject.toml
+
+# Generated output
+graphify-out/
+output/
+data/cache/
+htmlcov/
+.coverage
+
+# Images (no graph signal for a code project)
+*.png
+
+# IDE
+.vscode/
+.idea/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -10,6 +10,7 @@ pyproject.toml
 
 # Generated output
 graphify-out/
+graphify-out-*/
 output/
 data/cache/
 htmlcov/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,13 @@ algo-cus/
 - Dashboard chart builders live in `dashboard/charts.py` and use `dashboard/theme.py` for dark styling
 - All `visualization/*.py` charts remain standalone (return `go.Figure`) — the dashboard composes them
 - New strategies register via `@register` decorator and appear in the dashboard automatically
+
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)


### PR DESCRIPTION
## Summary
- Wire graphify knowledge-graph into the project via `CLAUDE.md` rules + `.claude/settings.json` hook (PreToolUse on Glob/Grep, no-ops if `graph.json` absent)
- Define corpus filter in `.graphifyignore` (excludes tests, deployment config, dep manifests, build output, images, IDE dirs) so every developer's graph reflects the same source-of-truth
- Update `.gitignore`: share `.claude/settings.json` (team hook config) but keep local Claude state out; ignore `graphify-out/` and worktree variants

## Test plan
- [ ] `git clone` fresh, confirm `graphify-out/` doesn't appear and `.claude/settings.json` does
- [ ] Run `graphify .` in a fresh checkout, confirm `.graphifyignore` skips test files
- [ ] Run a `Grep` in Claude Code with `graphify-out/graph.json` present, confirm hook injects context
- [ ] Run a `Grep` without `graph.json`, confirm hook no-ops silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
